### PR TITLE
fix: quote hook commands in installer

### DIFF
--- a/cli/hook-command.ts
+++ b/cli/hook-command.ts
@@ -1,0 +1,3 @@
+export function formatHookCommand(nodePath: string, hookPath: string): string {
+  return `"${nodePath}" "${hookPath}"`;
+}

--- a/cli/install.test.ts
+++ b/cli/install.test.ts
@@ -1,0 +1,15 @@
+import { describe, test, expect } from "bun:test";
+import { formatHookCommand } from "./hook-command.ts";
+
+describe("formatHookCommand", () => {
+  test("quotes node and script paths so Windows paths with spaces survive", () => {
+    expect(
+      formatHookCommand(
+        "C:\\Program Files\\nodejs\\node.exe",
+        "C:\\Users\\me\\App Data\\petsonality\\hooks\\react.js",
+      ),
+    ).toBe(
+      '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\me\\App Data\\petsonality\\hooks\\react.js"',
+    );
+  });
+});

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -11,6 +11,7 @@ import { join, resolve, dirname } from "path";
 import { homedir, platform } from "os";
 import { findOpenClawTuiFile } from "./openclaw-patch.ts";
 import { whichSync } from "./which.ts";
+import { formatHookCommand } from "./hook-command.ts";
 
 const IS_WIN = platform() === "win32";
 
@@ -215,7 +216,7 @@ function installHooks(settings: Record<string, any>) {
     (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("petsonality") || hh.command?.includes("typet")),
   );
   settings.hooks.PostToolUse.push({
-    hooks: [{ type: "command", command: `${nodePath} ${reactHook}` }],
+    hooks: [{ type: "command", command: formatHookCommand(nodePath, reactHook) }],
   });
 
   // Stop — same cleanup
@@ -224,7 +225,7 @@ function installHooks(settings: Record<string, any>) {
     (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("petsonality") || hh.command?.includes("typet")),
   );
   settings.hooks.Stop.push({
-    hooks: [{ type: "command", command: `${nodePath} ${commentHook}` }],
+    hooks: [{ type: "command", command: formatHookCommand(nodePath, commentHook) }],
   });
 
   ok("Hooks registered: PostToolUse + Stop");


### PR DESCRIPTION
Fixes #3

Quotes both node and hook paths when writing Claude Code hook commands so Windows installs with "C:\Program Files" paths are parsed correctly.

Validation:
- bun test
- bun run build