### PR TITLE
fix(scripts): build-art path resolution on Windows

### DIFF
--- a/scripts/build-art.ts
+++ b/scripts/build-art.ts
@@ -9,14 +9,17 @@
  */
 
 import { readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import { ANIMAL_ART } from "../server/art.ts";
 import { ANIMALS, ANIMAL_COLOR } from "../server/engine.ts";
 import { ART_META } from "../server/art-meta.ts";
 import type { AnimalId } from "../server/engine.ts";
 
-// Resolve paths relative to this script's directory
-const SCRIPT_DIR = new URL(".", import.meta.url).pathname;
+// Resolve paths relative to this script's directory.
+// fileURLToPath gives a proper platform path; `new URL(...).pathname` returns
+// "/C:/..." on Windows which breaks downstream join() calls.
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(SCRIPT_DIR, "..");
 const SHELL_PATH = join(PROJECT_ROOT, "statusline", "pet-status.sh");
 


### PR DESCRIPTION
Surfaced while running `bun run build` on Win11 (the build:art step blocks any local install that needs to regenerate `dist/`):

```
ENOENT: no such file or directory, open '\C:\Users\...\statusline\pet-status.sh'
```

`new URL(".", import.meta.url).pathname` returns `/C:/...` on Windows (POSIX-style with leading slash). `join()`-ing that with a relative segment produced `\C:\...` which `fs.readFileSync` then failed to open.

Fix: switched to `dirname(fileURLToPath(import.meta.url))` — the same pattern already used in `cli/index.js` and `cli/openclaw-patch.ts`. Same anti-pattern, same shape of fix as #6.

This was the second commit on the original `fix/find-package-root-windows-infinite-loop` branch but didn't make it into the squash-merge of #6 / v0.4.3. Splitting it out as its own PR.

## Test plan

- [x] `bun run build` on Win11 — full pipeline succeeds, writes `dist/`, `statusline/pet-status.sh`, `~/.petsonality/reactions-pool.json`
- [x] `bun test` — 305 pass, 0 fail (no impact)
- [ ] macOS — confirm no regression in the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)