### PR TITLE
[codex] Prepare registry metadata and safer install prompts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,5 +28,5 @@ If applicable, add screenshots.
 **Status line output**
 ```
 # Run this and paste the output:
-echo '{}' | ~/.petsonality/../statusline/pet-status.sh 2>/dev/null
+echo '{}' | ~/.petsonality/statusline/pet-status.sh 2>/dev/null
 ```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,5 +11,11 @@ A clear description of the feature.
 **Why?**
 What problem does it solve or what experience does it improve?
 
+**Who is this for?**
+Which users, terminals, assistants, or workflows would benefit?
+
 **Ideas for implementation**
 If you have thoughts on how it could work, share them here.
+
+**Anything else?**
+Links, screenshots, examples from other tools, or constraints we should know.

--- a/PRD-v3.md
+++ b/PRD-v3.md
@@ -86,6 +86,7 @@
 - [ ] **真 Windows host 上 smoke test 0.4.5**（`npx petsonality@latest` + `/pet`）
 - [ ] **测 `claude plugin install github:nanami-he/petsonality`**（需要新装 Claude Code 测）
 - [ ] 提交 petsonality 到 [MCP Server Registry](https://modelcontextprotocol.io) 的 server directory
+- [x] MCP Registry 元数据准备：`server.json` + `package.json#mcpName`（正式 publish 要等下一次 npm 版本，让 npm registry 里的 package.json 带上 `mcpName`）
 - [x] README 加「Install」章节，列出 3 条路径（npx 主推，plugin 次推，git clone 给开发者）
 - [x] **dist/reactions-pool.json 改为确定性输出**（当前每次 build 都 reorder ~700 行，commit noise；改为对 array 排序后再 stringify）
 - [ ] （长期）写 Homebrew formula
@@ -94,7 +95,7 @@
 
 **进度（2026-04-29）**：核心架构 4/4 done（v0.4.5 已 ship），multi-channel 已经从「想法」变成「真有这条路径」。
 
-**进度（2026-05-01）**：README Install 章节补齐三条路径；`dist/reactions-pool.json` 输出改为确定性排序，减少每次 build 的 generated diff 噪音。剩余 G0 主要是 registry 提交、真实 plugin install smoke test、Windows host smoke test、长期 Homebrew。
+**进度（2026-05-01）**：README Install 章节补齐三条路径；`dist/reactions-pool.json` 输出改为确定性排序，减少每次 build 的 generated diff 噪音；MCP Registry 元数据已准备，下一次 npm publish 后即可跑 `mcp-publisher publish`。剩余 G0 主要是 registry 正式提交、真实 plugin install smoke test、Windows host smoke test、长期 Homebrew。
 
 ### G1: 社区推广
 - [x] Twitter/X 发帖（v0.4.0 launch tweet, 2026-04-18，reach 小但已发）
@@ -144,8 +145,8 @@
 
 ### M4: 安装侵入性透明化
 现状：`installStatusLine` 自动替换已有 statusLine（虽有 `.bak`），`installHooks` 重写既有 hook 条目。
-- [ ] 检测到现有非空 statusLine 时，prompt 用户确认 + 显示即将被覆盖的内容
-- [ ] hook 重写也走同样的"先 diff 再写"流程
+- [x] 检测到现有非空 statusLine 时，prompt 用户确认 + 显示即将被覆盖的内容
+- [x] hook 重写也走同样的"先 diff 再写"流程
 - [ ] 长期等 OpenClaw merge PR #65886 后，TUI patch 路径完全废弃
 - 决策记录：短期接受侵入式安装 + 自动 backup 兜底是 conscious choice，优先开发速度，但推广开始后用户初见信任成本会上升
 
@@ -164,7 +165,7 @@
 - [x] `CONTRIBUTING.md` —— dev setup + commit conv + PR flow + project layout
 - [x] 2 个 `good first issue`（#3 已 close, #4 仍 open）
 - [x] **首个外部 PR 跑通了**：from issue 开出 → 2h 收到 PR → 6h merge → 同 commit ship → contributor 上 README → 公开 thank-you。**整套 OSS 协作循环验证可用**
-- [ ] Issue / PR template review（已有 bug-report.yml；考虑加 feature_request.yml）
+- [x] Issue / PR template review（bug report statusline smoke 命令修正，feature request 增加受众/补充材料字段）
 
 ---
 

--- a/cli/install-transparency.test.ts
+++ b/cli/install-transparency.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  findPetsonalityHookEntries,
+  statusLineReplacementPreview,
+} from "./install-transparency.ts";
+
+describe("install transparency", () => {
+  test("prompts before replacing a non-petsonality status line", () => {
+    expect(
+      statusLineReplacementPreview(
+        { command: "/usr/local/bin/starship status", refreshInterval: 1 },
+        { command: "/Users/me/.petsonality/statusline/pet-status.sh", refreshInterval: 1, padding: 1, type: "command" },
+      ),
+    ).toEqual({
+      existing: { command: "/usr/local/bin/starship status", refreshInterval: 1 },
+      next: { command: "/Users/me/.petsonality/statusline/pet-status.sh", refreshInterval: 1, padding: 1, type: "command" },
+    });
+  });
+
+  test("does not prompt when refreshing a petsonality status line", () => {
+    expect(
+      statusLineReplacementPreview(
+        { command: "/Users/me/.petsonality/statusline/pet-status.sh", refreshInterval: 1 },
+        { command: "/Users/me/.petsonality/statusline/pet-status.sh", refreshInterval: 1, padding: 1, type: "command" },
+      ),
+    ).toBeNull();
+  });
+
+  test("finds only petsonality or legacy hook entries for replacement", () => {
+    const hooks = [
+      { hooks: [{ type: "command", command: "node /tmp/third-party.js" }] },
+      { hooks: [{ type: "command", command: "node ~/.petsonality/hooks/react.js" }] },
+      { hooks: [{ type: "command", command: "node ~/.typet/hooks/react.js" }] },
+    ];
+
+    expect(findPetsonalityHookEntries(hooks)).toEqual([hooks[1], hooks[2]]);
+  });
+});

--- a/cli/install-transparency.ts
+++ b/cli/install-transparency.ts
@@ -1,0 +1,33 @@
+export interface ReplacementPreview {
+  existing: unknown;
+  next: unknown;
+}
+
+export function isPetsonalityCommand(command: unknown): boolean {
+  return typeof command === "string" && (command.includes("petsonality") || command.includes("typet"));
+}
+
+export function statusLineReplacementPreview(existing: unknown, next: unknown): ReplacementPreview | null {
+  if (!existing || typeof existing !== "object") return null;
+  const command = (existing as { command?: unknown }).command;
+  if (!command || isPetsonalityCommand(command)) return null;
+  return { existing, next };
+}
+
+export function findPetsonalityHookEntries(entries: unknown): unknown[] {
+  if (!Array.isArray(entries)) return [];
+  return entries.filter((entry) =>
+    Array.isArray((entry as { hooks?: unknown }).hooks)
+    && ((entry as { hooks: Array<{ command?: unknown }> }).hooks).some((hook) => isPetsonalityCommand(hook.command)),
+  );
+}
+
+export function formatReplacementPreview(title: string, preview: ReplacementPreview): string {
+  return [
+    title,
+    "Current:",
+    JSON.stringify(preview.existing, null, 2),
+    "Petsonality will write:",
+    JSON.stringify(preview.next, null, 2),
+  ].join("\n");
+}

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -14,6 +14,13 @@ import { whichSync } from "./which.ts";
 import { formatHookCommand } from "./hook-command.ts";
 import { findPackageRoot } from "./find-package-root.ts";
 import { statusLineConfigForPlatform, formatStatusLineCommand } from "./statusline-config.ts";
+import { createInterface } from "readline/promises";
+import { stdin as input, stdout as output } from "process";
+import {
+  findPetsonalityHookEntries,
+  formatReplacementPreview,
+  statusLineReplacementPreview,
+} from "./install-transparency.ts";
 
 const CURRENT_PLATFORM = platform();
 const IS_WIN = CURRENT_PLATFORM === "win32";
@@ -44,6 +51,28 @@ function ok(msg: string) { console.log(`${GREEN}✓${NC}  ${msg}`); }
 function info(msg: string) { console.log(`${CYAN}→${NC}  ${msg}`); }
 function warn(msg: string) { console.log(`${YELLOW}⚠${NC}  ${msg}`); }
 function err(msg: string) { console.log(`${RED}✗${NC}  ${msg}`); }
+
+async function confirmChange(title: string, existing: unknown, next: unknown): Promise<boolean> {
+  console.log("");
+  console.log(formatReplacementPreview(`${YELLOW}${title}${NC}`, { existing, next }));
+
+  if (process.env.PETSONALITY_ASSUME_YES === "1") {
+    info("PETSONALITY_ASSUME_YES=1 set — continuing");
+    return true;
+  }
+  if (!input.isTTY) {
+    warn("Non-interactive install — continuing for backwards compatibility");
+    return true;
+  }
+
+  const rl = createInterface({ input, output });
+  try {
+    const answer = await rl.question("Replace this config? [y/N] ");
+    return answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes";
+  } finally {
+    rl.close();
+  }
+}
 
 // ─── Preflight checks ──────────────────────────────────────────────────────
 
@@ -149,15 +178,21 @@ function installSkill() {
 
 // ─── Step 3: Status line ───────────────────────────────────────────────────
 
-function installStatusLine(settings: Record<string, any>) {
-  if (settings.statusLine?.command && !settings.statusLine.command.includes("petsonality") && !settings.statusLine.command.includes("typet")) {
-    warn(`Existing statusLine found: ${settings.statusLine.command}`);
-    warn("Replacing with petsonality status line. Old config backed up in ~/.petsonality/statusline.bak");
-
+async function installStatusLine(settings: Record<string, any>) {
+  const nextStatusLine = statusLineConfigForPlatform(CURRENT_PLATFORM, RUNTIME_DIR);
+  const preview = statusLineReplacementPreview(settings.statusLine, nextStatusLine);
+  if (preview) {
+    warn("Existing non-petsonality statusLine found.");
+    const confirmed = await confirmChange("Petsonality statusLine replacement", preview.existing, preview.next);
+    if (!confirmed) {
+      warn("Skipped status line configuration at your request");
+      return;
+    }
     mkdirSync(join(homedir(), ".petsonality"), { recursive: true });
     writeFileSync(join(homedir(), ".petsonality", "statusline.bak"), JSON.stringify(settings.statusLine, null, 2));
+    warn("Old config backed up in ~/.petsonality/statusline.bak");
   }
-  settings.statusLine = statusLineConfigForPlatform(CURRENT_PLATFORM, RUNTIME_DIR);
+  settings.statusLine = nextStatusLine;
   ok(IS_WIN ? "PowerShell status line configured" : "Status line configured");
   if (IS_WIN) {
     info("If Claude Code does not render the status line, accept the project trust dialog and restart Claude Code.");
@@ -192,7 +227,26 @@ const RUNTIME_DIR = join(homedir(), ".petsonality");
 
 // ─── Step 4: Hooks ─────────────────────────────────────────────────────────
 
-function installHooks(settings: Record<string, any>) {
+async function replacePetsonalityHookEntries(settings: Record<string, any>, hookType: "PostToolUse" | "Stop", nextEntry: Record<string, any>): Promise<boolean> {
+  if (!settings.hooks[hookType]) settings.hooks[hookType] = [];
+
+  const existingEntries = findPetsonalityHookEntries(settings.hooks[hookType]);
+  if (existingEntries.length > 0) {
+    const confirmed = await confirmChange(`Petsonality ${hookType} hook replacement`, existingEntries, nextEntry);
+    if (!confirmed) {
+      warn(`Skipped ${hookType} hook replacement at your request`);
+      return false;
+    }
+  }
+
+  settings.hooks[hookType] = settings.hooks[hookType].filter(
+    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("petsonality") || hh.command?.includes("typet")),
+  );
+  settings.hooks[hookType].push(nextEntry);
+  return true;
+}
+
+async function installHooks(settings: Record<string, any>) {
   const reactHook = join(RUNTIME_DIR, "hooks", "react.js");
   const commentHook = join(RUNTIME_DIR, "hooks", "pet-comment.js");
 
@@ -201,25 +255,18 @@ function installHooks(settings: Record<string, any>) {
   // Resolve node path for hooks (cross-platform; same node that's running this installer).
   const nodePath = process.execPath;
 
-  // PostToolUse — clean up both old (typet) and new (petsonality) entries
-  if (!settings.hooks.PostToolUse) settings.hooks.PostToolUse = [];
-  settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(
-    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("petsonality") || hh.command?.includes("typet")),
-  );
-  settings.hooks.PostToolUse.push({
+  const postToolUseEntry = {
     hooks: [{ type: "command", command: formatHookCommand(nodePath, reactHook) }],
-  });
+  };
 
-  // Stop — same cleanup
-  if (!settings.hooks.Stop) settings.hooks.Stop = [];
-  settings.hooks.Stop = settings.hooks.Stop.filter(
-    (h: any) => !h.hooks?.some((hh: any) => hh.command?.includes("petsonality") || hh.command?.includes("typet")),
-  );
-  settings.hooks.Stop.push({
+  const stopEntry = {
     hooks: [{ type: "command", command: formatHookCommand(nodePath, commentHook) }],
-  });
+  };
 
-  ok("Hooks registered: PostToolUse + Stop");
+  const postToolUseInstalled = await replacePetsonalityHookEntries(settings, "PostToolUse", postToolUseEntry);
+  const stopInstalled = await replacePetsonalityHookEntries(settings, "Stop", stopEntry);
+
+  if (postToolUseInstalled || stopInstalled) ok("Hooks registered: PostToolUse + Stop");
 }
 
 // ─── Step 5: Permissions ───────────────────────────────────────────────────
@@ -342,8 +389,8 @@ if (hosts.claude) {
   const settings = loadSettings();
   installMcp();
   installSkill();
-  installStatusLine(settings);
-  installHooks(settings);
+  await installStatusLine(settings);
+  await installHooks(settings);
   ensurePermissions(settings);
   saveSettings(settings);
 } else {

--- a/dist/cli/install.js
+++ b/dist/cli/install.js
@@ -428,6 +428,38 @@ function statusLineConfigForPlatform(currentPlatform, runtimeDir) {
 }
 
 // cli/install.ts
+import { createInterface } from "readline/promises";
+import { stdin as input, stdout as output } from "process";
+
+// cli/install-transparency.ts
+function isPetsonalityCommand(command) {
+  return typeof command === "string" && (command.includes("petsonality") || command.includes("typet"));
+}
+function statusLineReplacementPreview(existing, next) {
+  if (!existing || typeof existing !== "object")
+    return null;
+  const command = existing.command;
+  if (!command || isPetsonalityCommand(command))
+    return null;
+  return { existing, next };
+}
+function findPetsonalityHookEntries(entries) {
+  if (!Array.isArray(entries))
+    return [];
+  return entries.filter((entry) => Array.isArray(entry.hooks) && entry.hooks.some((hook) => isPetsonalityCommand(hook.command)));
+}
+function formatReplacementPreview(title, preview) {
+  return [
+    title,
+    "Current:",
+    JSON.stringify(preview.existing, null, 2),
+    "Petsonality will write:",
+    JSON.stringify(preview.next, null, 2)
+  ].join(`
+`);
+}
+
+// cli/install.ts
 var CURRENT_PLATFORM = platform3();
 var IS_WIN3 = CURRENT_PLATFORM === "win32";
 var CYAN2 = "\x1B[36m";
@@ -460,6 +492,25 @@ function warn2(msg) {
 }
 function err2(msg) {
   console.log(`${RED2}✗${NC2}  ${msg}`);
+}
+async function confirmChange(title, existing, next) {
+  console.log("");
+  console.log(formatReplacementPreview(`${YELLOW2}${title}${NC2}`, { existing, next }));
+  if (process.env.PETSONALITY_ASSUME_YES === "1") {
+    info2("PETSONALITY_ASSUME_YES=1 set — continuing");
+    return true;
+  }
+  if (!input.isTTY) {
+    warn2("Non-interactive install — continuing for backwards compatibility");
+    return true;
+  }
+  const rl = createInterface({ input, output });
+  try {
+    const answer = await rl.question("Replace this config? [y/N] ");
+    return answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes";
+  } finally {
+    rl.close();
+  }
 }
 function detectHosts() {
   const claude = existsSync4(CLAUDE_DIR) && existsSync4(join5(homedir2(), ".claude.json"));
@@ -541,14 +592,21 @@ function installSkill() {
   cpSync(srcSkill, join5(SKILL_DIR, "SKILL.md"), { force: true });
   ok2("Skill installed: ~/.claude/skills/pet/SKILL.md");
 }
-function installStatusLine(settings) {
-  if (settings.statusLine?.command && !settings.statusLine.command.includes("petsonality") && !settings.statusLine.command.includes("typet")) {
-    warn2(`Existing statusLine found: ${settings.statusLine.command}`);
-    warn2("Replacing with petsonality status line. Old config backed up in ~/.petsonality/statusline.bak");
+async function installStatusLine(settings) {
+  const nextStatusLine = statusLineConfigForPlatform(CURRENT_PLATFORM, RUNTIME_DIR);
+  const preview = statusLineReplacementPreview(settings.statusLine, nextStatusLine);
+  if (preview) {
+    warn2("Existing non-petsonality statusLine found.");
+    const confirmed = await confirmChange("Petsonality statusLine replacement", preview.existing, preview.next);
+    if (!confirmed) {
+      warn2("Skipped status line configuration at your request");
+      return;
+    }
     mkdirSync(join5(homedir2(), ".petsonality"), { recursive: true });
     writeFileSync2(join5(homedir2(), ".petsonality", "statusline.bak"), JSON.stringify(settings.statusLine, null, 2));
+    warn2("Old config backed up in ~/.petsonality/statusline.bak");
   }
-  settings.statusLine = statusLineConfigForPlatform(CURRENT_PLATFORM, RUNTIME_DIR);
+  settings.statusLine = nextStatusLine;
   ok2(IS_WIN3 ? "PowerShell status line configured" : "Status line configured");
   if (IS_WIN3) {
     info2("If Claude Code does not render the status line, accept the project trust dialog and restart Claude Code.");
@@ -571,25 +629,37 @@ function installRuntimeFiles() {
   ok2("Runtime files copied to ~/.petsonality/");
 }
 var RUNTIME_DIR = join5(homedir2(), ".petsonality");
-function installHooks(settings) {
+async function replacePetsonalityHookEntries(settings, hookType, nextEntry) {
+  if (!settings.hooks[hookType])
+    settings.hooks[hookType] = [];
+  const existingEntries = findPetsonalityHookEntries(settings.hooks[hookType]);
+  if (existingEntries.length > 0) {
+    const confirmed = await confirmChange(`Petsonality ${hookType} hook replacement`, existingEntries, nextEntry);
+    if (!confirmed) {
+      warn2(`Skipped ${hookType} hook replacement at your request`);
+      return false;
+    }
+  }
+  settings.hooks[hookType] = settings.hooks[hookType].filter((h) => !h.hooks?.some((hh) => hh.command?.includes("petsonality") || hh.command?.includes("typet")));
+  settings.hooks[hookType].push(nextEntry);
+  return true;
+}
+async function installHooks(settings) {
   const reactHook = join5(RUNTIME_DIR, "hooks", "react.js");
   const commentHook = join5(RUNTIME_DIR, "hooks", "pet-comment.js");
   if (!settings.hooks)
     settings.hooks = {};
   const nodePath = process.execPath;
-  if (!settings.hooks.PostToolUse)
-    settings.hooks.PostToolUse = [];
-  settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter((h) => !h.hooks?.some((hh) => hh.command?.includes("petsonality") || hh.command?.includes("typet")));
-  settings.hooks.PostToolUse.push({
+  const postToolUseEntry = {
     hooks: [{ type: "command", command: formatHookCommand(nodePath, reactHook) }]
-  });
-  if (!settings.hooks.Stop)
-    settings.hooks.Stop = [];
-  settings.hooks.Stop = settings.hooks.Stop.filter((h) => !h.hooks?.some((hh) => hh.command?.includes("petsonality") || hh.command?.includes("typet")));
-  settings.hooks.Stop.push({
+  };
+  const stopEntry = {
     hooks: [{ type: "command", command: formatHookCommand(nodePath, commentHook) }]
-  });
-  ok2("Hooks registered: PostToolUse + Stop");
+  };
+  const postToolUseInstalled = await replacePetsonalityHookEntries(settings, "PostToolUse", postToolUseEntry);
+  const stopInstalled = await replacePetsonalityHookEntries(settings, "Stop", stopEntry);
+  if (postToolUseInstalled || stopInstalled)
+    ok2("Hooks registered: PostToolUse + Stop");
 }
 function ensurePermissions(settings) {
   if (!settings.permissions)
@@ -697,8 +767,8 @@ if (hosts.claude) {
   const settings = loadSettings();
   installMcp();
   installSkill();
-  installStatusLine(settings);
-  installHooks(settings);
+  await installStatusLine(settings);
+  await installHooks(settings);
   ensurePermissions(settings);
   saveSettings(settings);
 } else {

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -1,0 +1,25 @@
+# MCP Registry publishing
+
+Petsonality registry name: `io.github.nanami-he/petsonality`
+
+The official MCP Registry validates npm packages by checking that the published package's `package.json` has an `mcpName` field matching `server.json#name`.
+
+## Current state
+
+- `server.json` is ready for the MCP Registry.
+- `package.json#mcpName` is ready for the next npm publish.
+- The currently published `petsonality@0.4.5` package was published before `mcpName` existed, so registry publishing should wait for the next package version.
+
+## Publish checklist
+
+1. Run `bun test`.
+2. Run `bun run build`.
+3. Publish the next npm version so npm contains `mcpName`.
+4. Install or update `mcp-publisher`.
+5. Run `mcp-publisher login github`.
+6. Run `mcp-publisher publish`.
+7. Verify with:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.nanami-he/petsonality"
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "petsonality",
   "version": "0.4.5",
+  "mcpName": "io.github.nanami-he/petsonality",
   "description": "Your type, your pet.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.nanami-he/petsonality",
+  "title": "Petsonality",
+  "description": "An MBTI-powered terminal pet companion for Claude Code and OpenClaw.",
+  "repository": {
+    "url": "https://github.com/nanami-he/petsonality",
+    "source": "github"
+  },
+  "version": "0.4.5",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "petsonality",
+      "version": "0.4.5",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Sync local maintenance branch from merged `main` and continue the PRD 1/2/4/5 workstream.
- Add MCP Registry metadata with `server.json`, `package.json#mcpName`, and a registry publishing checklist.
- Make the installer show the existing config and ask before replacing a non-petsonality `statusLine` or stale petsonality/typet hook entries.
- Improve GitHub issue templates by fixing the statusline smoke command and adding more useful feature-request fields.
- Update PRD progress for G0 registry metadata, M4 install transparency, and M6 templates.

## Validation

- `bun test` -> 322 pass, 0 fail
- `bun run build` -> succeeds; generated `dist/cli/install.js` updated
- `NPM_CONFIG_CACHE=/private/tmp/petsonality-npm-cache npm pack --dry-run` -> succeeds; tarball contains expected 15 files including `dist/cli/install.js`, `dist/server.js`, and `package.json`
- `node -e "JSON.parse(...)"` over `server.json` and `package.json` -> `json ok`

## Registry note

This prepares registry metadata but does not publish Petsonality to the MCP Registry yet. The currently published npm `petsonality@0.4.5` predates `package.json#mcpName`, so the actual `mcp-publisher publish` step should wait until the next npm version is published with that field included.